### PR TITLE
Fix doc review findings across MRZ JS docs (#45-#55)

### DIFF
--- a/api/enums-mrz-scanner.md
+++ b/api/enums-mrz-scanner.md
@@ -52,8 +52,37 @@ enum EnumMRZData {
   Age = "age",
   Sex = "sex",
   IssuingState = "issuingState",
+  IssuingStateRaw = "issuingStateRaw",
   Nationality = "nationality",
+  NationalityRaw = "nationalityRaw",
   DateOfBirth = "dateOfBirth",
   DateOfExpiry = "dateOfExpiry",
+}
+```
+
+## EnumMRZScanMode
+
+### Syntax
+
+```ts
+enum EnumMRZScanMode {
+  Passport = "passport",
+  TD1 = "td1",
+  TD2 = "td2",
+  PassportAndTD1 = "passportAndTD1",
+  PassportAndTD2 = "passportAndTD2",
+  TD1AndTD2 = "td1AndTD2",
+  All = "all",
+}
+```
+
+## EnumMRZScannerViews
+
+### Syntax
+
+```ts
+enum EnumMRZScannerViews {
+  Scanner = "scanner",
+  Result = "scan-result",
 }
 ```

--- a/api/index.md
+++ b/api/index.md
@@ -18,9 +18,9 @@ Please read through the [**full API reference**](mrz-scanner.md), but you can fi
 
 1. [MRZScanner](mrz-scanner.md#mrzscanner) - The main class of the MRZ Scanner, which is used to create and configure the MRZ Scanner instance.
 
-2. MRZScannerView - Represents the main view of the MRZ Scanner where the scanning operation occurs.
+2. [MRZScannerView](mrz-scanner.md#mrzscannerview) - Represents the main view of the MRZ Scanner where the scanning operation occurs.
 
-3. MRZResultView - Displays the parsed MRZ result in human readable fields, along with a cropped image of the MRZ document.
+3. [MRZResultView](mrz-scanner.md#mrzresultview) - Displays the parsed MRZ result in human readable fields, along with a cropped image of the MRZ document.
 
 ## Interfaces
 
@@ -46,4 +46,8 @@ All of the enumerations can be found [**here**](enums-mrz-scanner.md). Here is a
 
 2. [EnumResultStatus](enums-mrz-scanner.md#enumresultstatus) - An enumeration to represent the status of a MRZ result.
 
-3. [EnumMRZData](enums-mrz-scanner.md) - An enumeration to represent the different fields of the `MRZData` interface.
+3. [EnumMRZData](enums-mrz-scanner.md#enummrzdata) - An enumeration to represent the different fields of the `MRZData` interface.
+
+4. [EnumMRZScanMode](enums-mrz-scanner.md#enummrzscanmode) - An enumeration to represent preset combinations of supported MRZ scan formats.
+
+5. [EnumMRZScannerViews](enums-mrz-scanner.md#enummrzscannerviews) - An enumeration to represent built-in scanner view IDs.

--- a/api/mrz-scanner.md
+++ b/api/mrz-scanner.md
@@ -52,8 +52,12 @@ Starts the **MRZ scanning workflow**. If the method is run without a file input,
 ```ts
 launch(): Promise<MRZResult>
 
-launch(fileToProcess): Promise<MRZResult>
+launch(imageOrFile?: Blob | string | DSImageData | HTMLImageElement | HTMLVideoElement | HTMLCanvasElement): Promise<MRZResult>
 ```
+
+#### Parameters
+
+- `imageOrFile` (optional): A static input to process directly. Supported types are `Blob`, `string`, `DSImageData`, `HTMLImageElement`, `HTMLVideoElement`, and `HTMLCanvasElement`.
 
 #### Returns
 
@@ -77,11 +81,44 @@ A `Promise` resolving to a `MRZResult` object.
 (async () => {
     // Launch the scanner and wait for the result
     try {
-        const result = await mrzScanner.launch(fileToProcess);
+        const result = await mrzScanner.launch(imageOrFile);
         console.log(result); // print the MRZResult to the console
     } catch (error){
         console.error("Error processing file:", error);
     }
+})();
+```
+
+### initialize()
+
+Initializes the MRZ Scanner resources and returns access to shared resources and view components for advanced workflows.
+
+#### Syntax
+
+```ts
+initialize(): Promise<{
+  resources: SharedResources;
+  components: {
+    scannerView?: MRZScannerView;
+    resultView?: MRZResultView;
+  };
+}>
+```
+
+#### Returns
+
+A `Promise` resolving to an object that contains:
+
+- `resources`: Shared scanner resources.
+- `components`: View components that may include `scannerView` and `resultView`.
+
+#### Example
+
+```ts
+(async () => {
+    const initialized = await mrzScanner.initialize();
+    console.log(initialized.components.scannerView);
+    console.log(initialized.components.resultView);
 })();
 ```
 
@@ -103,6 +140,41 @@ console.log("Scanner resources released.");
 ```
 
 ## Configuration Interfaces
+
+## View Classes
+
+### MRZScannerView
+
+Represents the scanning UI view and camera lifecycle controls.
+
+#### Syntax
+
+```ts
+class MRZScannerView {
+  initialize(): Promise<void>;
+  openCamera(): Promise<void>;
+  closeCamera(): Promise<void>;
+  pauseCamera(): Promise<void>;
+  stopCapturing(): Promise<void>;
+  handleMRZResult(result: MRZResult): Promise<void>;
+  launch(imageOrFile?: Blob | string | DSImageData | HTMLImageElement | HTMLVideoElement | HTMLCanvasElement): Promise<MRZResult>;
+}
+```
+
+### MRZResultView
+
+Represents the result UI view that displays parsed MRZ data.
+
+#### Syntax
+
+```ts
+class MRZResultView {
+  launch(result: MRZResult): Promise<void>;
+  initialize(): Promise<void>;
+  hideView(): void;
+  dispose(): void;
+}
+```
 
 ### MRZScannerConfig
 
@@ -183,6 +255,7 @@ The MRZScannerViewConfig is used to configure the UI elements of the **MRZScanne
 ```ts
 interface MRZScannerViewConfig {
   uiPath?: string;
+  cameraEnhancerUIPath?: string;
   container?: HTMLElement | string;
 
   showScanGuide?: boolean;
@@ -191,8 +264,9 @@ interface MRZScannerViewConfig {
   showSoundToggle?: boolean;
   showPoweredByDynamsoft?: boolean;
 
-  enableMultiFrameCrossFilter?: boolean; // false by default
+  enableMultiFrameCrossFilter?: boolean; // true by default
 
+  mrzFormatType?: EnumMRZDocumentType | Array<EnumMRZDocumentType>;
   uploadAcceptedTypes?: string;
   uploadFileConverter?: (file: File) => Promise<Blob>;
 }
@@ -203,6 +277,7 @@ interface MRZScannerViewConfig {
 | Property                | Type                           | Description                                                     |
 | ----------------------- | ------------------------------ | --------------------------------------------------------------- |
 | `uiPath`  | `string`                 | Path to the custom Camera Enhancer UI (`.html` template file) for the scanner view.               |
+| `cameraEnhancerUIPath`  | `string`                 | Deprecated alias of `uiPath`, preserved for backward compatibility.               |
 | `container`             | `HTMLElement \ string`  | The container element or selector for the `MRZScannerView` UI. |
 | `showScanGuide`         | `boolean`                | Determines whether the scan guide frame will be displayed or not.  |
 | `showUploadImage`       | `boolean`                | Determines the visibility of the "load image" icon to allow the user to select a static image from their local photo library.              |
@@ -210,6 +285,7 @@ interface MRZScannerViewConfig {
 | `showSoundToggle`       | `boolean`                | Determines the visibility of the "sound" icon that allows the user to play a beep sound once the MRZ is recognized.        |
 | `showPoweredByDynamsoft`       | `boolean`         | Determines the visibility of the "Powered By Dynamsoft" imessage at the bottom of the scanner view.        |
 | `enableMultiFrameCrossFilter`      | `boolean`     | Enables or disables the MultiFrameResultCrossFilter that can improve the accuracy of the MRZ result, but possibly at the cost of speed.   |
+| `mrzFormatType`      | `EnumMRZDocumentType \| Array<EnumMRZDocumentType>`     | Restricts supported MRTD format(s) for this scanner view instance.   |
 | `uploadAcceptedTypes`      | `string`     | Configures which image and file format(s) the library will accept if the user chooses to decode static images. |
 | `uploadFileConverter`      | `function`     | Converts non-image files (e.g. PDF) to blobs so that they can be read by the MRZ Scanner.  |
 
@@ -221,9 +297,10 @@ const mrzScanViewConfig = {
     showUploadImage: true, // hides the load image icon that shows up in the toolbar at the top of the view; true by default
     showFormatSelector: true, // hides the format selector box if more than two MRZ types are assigned; true by default
     showSoundToggle: false, // hides the sound icon that allows the user to control whether a beep is played once an MRZ is recognized; true by default
-    showPoweredByDynamsoft: false; // hides the "Powered By Dynamsoft" message that appears on the scanner UI; true by default
+    showPoweredByDynamsoft: false, // hides the "Powered By Dynamsoft" message that appears on the scanner UI; true by default
     enableMultiFrameCrossFilter: true, // turning the filter off could improve the speed but at the cost of result accuracy; true by default
 
+    mrzFormatType: ["passport", "td1"], // limits this view to TD3 and TD1
     uploadAcceptedTypes: "image/*,application/pdf", // allows the user to upload static images and PDFs to be read by the MRZ Scanner - default is "image/*"
     uploadFileConverter: async (file) => {
         if (file.type === "application/pdf") {
@@ -286,9 +363,9 @@ const mrzResultViewConfig = {
     showMRZText: false, // Hides the raw MRZ text as a field in the result view; true by default
     emptyResultMessage: "No MRZ is detected. Please try again.", // Change the message if there is no MRZ is detected. The default message is "The necessary information couldn't be detected. Please try again."
     toolbarButtonsConfig: {
-        retake: {
-            label: "Re-scan", // Changes the text label of the retake button to "Re-scan"; string is "Re-take" by default
-            isHidden: true // Hides the retake button; false by default
+        rescan: {
+            label: "Re-scan", // Changes the text label of the rescan button to "Re-scan"; string is "Re-scan" by default
+            isHidden: true // Hides the rescan button; false by default
         },
         done: {
             label: "Return Home", // Changes the text label of the done button to "Return Home"; string is "Done" by default
@@ -324,9 +401,9 @@ The `MRZResultViewToolbarButtonsConfig` is used to configure the buttons of the 
 
 ```ts
 interface MRZResultViewToolbarButtonsConfig {
-  retake?: ToolbarButtonConfig;
+  rescan?: ToolbarButtonConfig;
   done?: ToolbarButtonConfig;
-  cancel?: ToolbarButtonConfig;
+  cancel?: ToolbarButton;
 }
 ```
 
@@ -334,15 +411,15 @@ interface MRZResultViewToolbarButtonsConfig {
 
 | Property                | Type                           | Description                                                     |
 | ----------------------- | ------------------------------ | --------------------------------------------------------------- |
-| `retake`    | [`ToolbarButtonConfig`](#toolbarbuttonconfig)  | Configuration for the re-scan button of the toolbar.   |
+| `rescan`    | [`ToolbarButtonConfig`](#toolbarbuttonconfig)  | Configuration for the re-scan button of the toolbar.   |
 | `done`      | [`ToolbarButtonConfig`](#toolbarbuttonconfig)  | Configuration for the done button of the toolbar.  |
-| `cancel`      | [`ToolbarButtonConfig`](#toolbarbuttonconfig)  | Configuration for the cancel button of the toolbar (which only shows up if the MRZ Scanner is launched with a static file instead of the standard camera UI).  |
+| `cancel`      | [`ToolbarButton`](#toolbarbutton)  | Full configuration for the cancel button of the toolbar (which only shows up if the MRZ Scanner is launched with a static file instead of the standard camera UI).  |
 
 #### Example
 
 ```ts
 const mrzButtonConfig = {
-    retake: {
+    rescan: {
         label: "Re-scan",
         isHidden: false
     },
@@ -360,6 +437,36 @@ const mrzResultViewConfig = {
     toolbarButtonsConfig: mrzButtonConfig,
 };
 ```
+
+### ToolbarButton
+
+The full interface used for toolbar buttons with click handling and visibility/disabled state controls.
+
+#### Syntax
+
+```ts
+export interface ToolbarButton {
+  id: string;
+  icon: string;
+  label: string;
+  onClick?: () => void | Promise<void>;
+  className?: string;
+  isDisabled?: boolean;
+  isHidden?: boolean;
+}
+```
+
+#### Properties
+
+| Property                | Type                           | Description                                                     |
+| ----------------------- | ------------------------------ | --------------------------------------------------------------- |
+| `id`         | `string`  | A unique identifier of the button. |
+| `icon`       | `string`  | The path to a custom icon (png/svg) for the button.  |
+| `label`      | `string`  | The text label of the button.  |
+| `onClick`    | `() => void \| Promise<void>`  | Callback executed when the button is clicked. |
+| `className`  | `string`  | Assigns a custom class to the button (usually to apply custom styling).  |
+| `isDisabled` | `boolean` | Disables/enables the button. |
+| `isHidden`   | `boolean` | Hides/shows the button in the toolbar.  |
 
 ### ToolbarButtonConfig
 
@@ -459,7 +566,7 @@ export interface MRZData {
 | `mrzText`         | `string`  | The raw unparsed text of the MRZ.              |
 | `firstName`       | `string`  | The first name of the MRZ document holder.  |
 | `lastName`        | `string`  | The last name of the MRZ document holder.      |
-| `age`             | `string`  | The age of the MRZ document holder.      |
+| `age`             | `number`  | The age of the MRZ document holder.      |
 | `sex`             | `string`  | The sex of the MRZ document holder.      |
 | `issuingState`    | `string`  | The issuing state (represented as the full name of the country/region) of the MRZ document.     |
 | `issuingStateRaw`    | `string`  | The raw text from the MRZ string of the issuing state of the MRZ document.     |
@@ -518,7 +625,7 @@ interface MRZDate {
 
 ### ResultStatus
 
-ResultStatus is used to represent the status of the MRZ Result. This status can be **successful**, **cancelled** if the user closes the scanner, or **failed** if something went wrong during the scanning process. The *code* of the result status is a [`EnumResultStatus`]({{ site.api }}enums-mrz-scanner.md#enumresultstatus).
+ResultStatus is used to represent the status of the MRZ Result. This status can be **successful**, **cancelled** if the user closes the scanner, or **failed** if something went wrong during the scanning process. The *code* of the result status is a [`EnumResultStatus`]({{ site.api }}enums-mrz-scanner.html#enumresultstatus).
 
 #### Syntax
 

--- a/gettingstarted/add_dependency.md
+++ b/gettingstarted/add_dependency.md
@@ -12,14 +12,7 @@ permalink: /gettingstarted/add_dependency.html
 
 # Adding the Dependency
 
-To build the solution, we need to include six packages
-
-1. `dynamsoft-label-recognizer`: Required. It defines the classes, interfaces, and enumerations specifically tailored for the Label Recognizer module.
-2. `dynamsoft-core`: Required. It encompasses common classes, interfaces, and enumerations that are shared across all SDKs in the Capture Vision architecture.
-3. `dynamsoft-license`: Required. It is responsible for the operations needed to initialize and operate the license.
-4. `dynamsoft-code-parser`: Required. It defines interfaces and enumerations specifically tailored to the Code Parser module.
-5. `dynamsoft-capture-vision-router`: Required. It defines the class `CaptureVisionRouter`, which governs the entire image processing workflow.
-6. `dynamsoft-camera-enhancer`: Required. It is used to define camera control features and capbilities as well as image acquisition features.
+To build a MRZ Scanner web app, include the `dynamsoft-mrz-scanner` SDK.
 
 ## Use a CDN
 
@@ -28,137 +21,46 @@ The simplest way to include the SDK is to use either the [jsDelivr](https://jsde
 - jsDelivr
 
   ```html
-  <script src="https://cdn.jsdelivr.net/npm/dynamsoft-document-viewer@2.0.0/dist/ddv.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/dynamsoft-core@3.2.10/dist/core.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/dynamsoft-license@3.2.10/dist/license.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/dynamsoft-document-normalizer@2.2.10/dist/ddn.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/dynamsoft-capture-vision-router@2.2.10/dist/cvr.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/dynamsoft-camera-enhancer@4.0.2/dist/dce.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dynamsoft-mrz-scanner@3.1.0/dist/mrz-scanner.bundle.js"></script>
   ```
 
 - UNPKG
 
   ```html
-  <script src="https://unpkg.com/dynamsoft-document-viewer@2.0.0/dist/ddv.js"></script>
-  <script src="https://unpkg.com/dynamsoft-core@3.2.10/dist/core.js"></script>
-  <script src="https://unpkg.com/dynamsoft-license@3.2.10/dist/license.js"></script>
-  <script src="https://unpkg.com/dynamsoft-document-normalizer@2.2.10/dist/ddn.js"></script>
-  <script src="https://unpkg.com/dynamsoft-capture-vision-router@2.2.10/dist/cvr.js"></script>
-  <script src="https://unpkg.com/dynamsoft-camera-enhancer@4.0.2/dist/dce.js"></script>
+  <script src="https://unpkg.com/dynamsoft-mrz-scanner@3.1.0/dist/mrz-scanner.bundle.js"></script>
   ```
 
-## Host yourself
+## Use npm or yarn
 
-Besides using the CDN, you can also download the SDKs and host related files on your own website/server before including it in your application. When using a CDN, resources related to `dynamsoft-image-processing` and `dynamsoft-capture-vision-std` are automatically loaded over the network; When using them locally, these two packages need to be configured manually.
+When using frameworks such as React, Vue, or Angular, add the package as a project dependency:
 
-**Step 1** - Download the SDKs:
-{% comment %}
-
-- From the website
-
-  [Download the JavaScript ZIP package](https://www.dynamsoft.com/mobile-web-capture/downloads/)
-
-- yarn
-
-  ```cmd
-  yarn add dynamsoft-document-viewer@2.0.0
-  yarn add dynamsoft-core@3.2.10
-  yarn add dynamsoft-license@3.2.10
-  yarn add dynamsoft-document-normalizer@2.2.10
-  yarn add dynamsoft-capture-vision-router@2.2.10
-  yarn add dynamsoft-capture-vision-std@1.2.0
-  yarn add dynamsoft-image-processing@2.2.10
-  yarn add dynamsoft-camera-enhancer@4.0.2
-  ```
-
-  {% endcomment %}
-
-- npm
-
-  ```cmd
-  npm install dynamsoft-document-viewer@2.0.0
-  npm install dynamsoft-core@3.2.10
-  npm install dynamsoft-license@3.2.10
-  npm install dynamsoft-document-normalizer@2.2.10
-  npm install dynamsoft-capture-vision-router@2.2.10
-  npm install dynamsoft-capture-vision-std@1.2.0
-  npm install dynamsoft-image-processing@2.2.10
-  npm install dynamsoft-camera-enhancer@4.0.2
-  ```
-
-**Step 2** - Include the SDKs
-
-Depending on where you put them, you can typically include them like this:
-{% comment %}
-
-```html
-<script src="./distributables/dynamsoft-document-viewer@2.0.0/dist/ddv.js"></script>
-<script src="./distributables/dynamsoft-core@3.2.10/dist/core.js"></script>
-<script src="./distributables/dynamsoft-license@3.2.10/dist/license.js"></script>
-<script src="./distributables/dynamsoft-document-normalizer@2.2.10/dist/ddn.js"></script>
-<script src="./distributables/dynamsoft-capture-vision-router@2.2.10/dist/cvr.js"></script>
-<script src="./distributables/dynamsoft-camera-enhancer@4.0.2/dist/dce.js"></script>
+```sh
+npm i dynamsoft-mrz-scanner@3.1.0 -E
+# or
+yarn add dynamsoft-mrz-scanner@3.1.0 -E
 ```
 
-or
-{% endcomment %}
+## Specify the location of engine files (framework usage)
 
-```html
-<script src="./node_modules/dynamsoft-document-viewer/dist/ddv.js"></script>
-<script src="./node_modules/dynamsoft-core/dist/core.js"></script>
-<script src="./node_modules/dynamsoft-license/dist/license.js"></script>
-<script src="./node_modules/dynamsoft-document-normalizer/dist/ddn.js"></script>
-<script src="./node_modules/dynamsoft-capture-vision-router/dist/cvr.js"></script>
-<script src="./node_modules/dynamsoft-camera-enhancer/dist/dce.js"></script>
-```
-
-**Step 3** Specify the location of the engine files(optinal)
-
-If you would like to use the SDKs completely offline, please refer to [Use your own hosted engine files](#use-your-own-hosted-engine-files).
-
-## Specify the location of the engine files
-
-This is usually only required with frameworks like Angular or React, etc. where the referenced JavaScript files such as cvr.js, ddn.js are compiled into another file, or hosting the engine files and using the SDKs completely offline. The purpose is to tell the SDK where to find the engine files (_.worker.js, _.wasm.js and \*.wasm, etc.).
-
-### Use the jsDelivr CDN with frameworks like Angular or React, etc.
+When the package is bundled by a build tool, set `engineResourcePaths` so the scanner can find engine files:
 
 ```typescript
-Dynamsoft.DDV.Core.engineResourcePath =
-  "https://cdn.jsdelivr.net/npm/dynamsoft-document-viewer@2.0.0/dist/engine";
 Dynamsoft.Core.CoreModule.engineResourcePaths.core =
-  "https://cdn.jsdelivr.net/npm/dynamsoft-core@3.2.10/dist/";
+  "https://cdn.jsdelivr.net/npm/dynamsoft-core/dist/";
 Dynamsoft.Core.CoreModule.engineResourcePaths.license =
-  "https://cdn.jsdelivr.net/npm/dynamsoft-license@3.2.10/dist/";
-Dynamsoft.Core.CoreModule.engineResourcePaths.ddn =
-  "https://cdn.jsdelivr.net/npm/dynamsoft-document-normalizer@2.2.10/dist/";
+  "https://cdn.jsdelivr.net/npm/dynamsoft-license/dist/";
 Dynamsoft.Core.CoreModule.engineResourcePaths.cvr =
-  "https://cdn.jsdelivr.net/npm/dynamsoft-capture-vision-router@2.2.10/dist/";
+  "https://cdn.jsdelivr.net/npm/dynamsoft-capture-vision-router/dist/";
+Dynamsoft.Core.CoreModule.engineResourcePaths.dlr =
+  "https://cdn.jsdelivr.net/npm/dynamsoft-label-recognizer/dist/";
+Dynamsoft.Core.CoreModule.engineResourcePaths.dcp =
+  "https://cdn.jsdelivr.net/npm/dynamsoft-code-parser/dist/";
 Dynamsoft.Core.CoreModule.engineResourcePaths.std =
-  "https://cdn.jsdelivr.net/npm/dynamsoft-capture-vision-std@1.2.0/dist/";
+  "https://cdn.jsdelivr.net/npm/dynamsoft-capture-vision-std/dist/";
 Dynamsoft.Core.CoreModule.engineResourcePaths.dip =
-  "https://cdn.jsdelivr.net/npm/dynamsoft-image-processing@2.2.10/dist/";
+  "https://cdn.jsdelivr.net/npm/dynamsoft-image-processing/dist/";
 Dynamsoft.Core.CoreModule.engineResourcePaths.dce =
-  "https://cdn.jsdelivr.net/npm/dynamsoft-camera-enhancer@4.0.2/dist/";
+  "https://cdn.jsdelivr.net/npm/dynamsoft-camera-enhancer/dist/";
 ```
 
-### Use your own hosted engine files
-
-```typescript
-//Feel free to change it to your own location of these files
-Dynamsoft.DDV.Core.engineResourcePath =
-  "./node_modules/dynamsoft-document-viewer/dist/engine";
-Dynamsoft.Core.CoreModule.engineResourcePaths.core =
-  "./node_modules/dynamsoft-core/dist/";
-Dynamsoft.Core.CoreModule.engineResourcePaths.license =
-  "./node_modules/dynamsoft-license/dist/";
-Dynamsoft.Core.CoreModule.engineResourcePaths.ddn =
-  "./node_modules/dynamsoft-document-normalizer/dist/";
-Dynamsoft.Core.CoreModule.engineResourcePaths.cvr =
-  "./node_modules/dynamsoft-capture-vision-router/dist/";
-Dynamsoft.Core.CoreModule.engineResourcePaths.std =
-  "./node_modules/dynamsoft-capture-vision-std/dist/";
-Dynamsoft.Core.CoreModule.engineResourcePaths.dip =
-  "./node_modules/dynamsoft-image-processing/dist/";
-Dynamsoft.Core.CoreModule.engineResourcePaths.dce =
-  "./node_modules/dynamsoft-camera-enhancer/dist/";
-```
+For complete setup and usage examples, see the [User Guide]({{ site.guides }}mrz-scanner.html).

--- a/guides/mrz-scanner-customization.md
+++ b/guides/mrz-scanner-customization.md
@@ -173,7 +173,7 @@ The `MRZResultView` displays parsed MRZ results and a cropped image of the MRTD 
 
 1. **`container`** - Assigns a specific DOM element to contain the `MRZResultView`. When not specified, the MRZ Scanner automatically creates its own container.
 
-2. **`toolbarButtonsConfig`** - Configures the `MRZResultView` toolbar (located in the footer in portrait mode, on the right side in landscape). The toolbar includes a **re-take button** that returns to the `MRZScannerView` for a new scan (discarding the current result) and a **done button** that closes the scanner and destroys the `MRZScanner` instance. When scanning a static file instead of using the camera, a **cancel button** appears in place of the re-take button.
+2. **`toolbarButtonsConfig`** - Configures the `MRZResultView` toolbar (located in the footer in portrait mode, on the right side in landscape). The toolbar includes a **rescan button** that returns to the `MRZScannerView` for a new scan (discarding the current result) and a **done button** that closes the scanner and destroys the `MRZScanner` instance. When scanning a static file instead of using the camera, a **cancel button** appears in place of the rescan button.
 
 3. **`showOriginalImage`** (default: `true`) - Toggles the cropped document image at the top of the result view. Set to `false` to hide the image.
 
@@ -200,14 +200,14 @@ const mrzScanner = new Dynamsoft.MRZScanner({
       allowResultEditing: true, // enables the ability to edit the result fields should the parsed information not match the MRZ document; false by default
       showMRZText: false, // hides the raw MRZ text as a result field in the result view; true by default
       toolbarButtonsConfig: {
-         retake: {
-            icon: "path to a png/svg file" // Changes the icon image of the retake button
-            label: "Re-scan", // Change the text label of the retake button to the provided string; string is "Re-take" by default
-            isHidden: true, // Hides the retake button; false by default
+         rescan: {
+            icon: "path to a png/svg file", // Changes the icon image of the rescan button
+            label: "Re-scan", // Change the text label of the rescan button to the provided string; string is "Re-scan" by default
+            isHidden: true, // Hides the rescan button; false by default
             className: "custom class name" // to implement a custom css to the done button, you can assign a custom css class to the button here
          },
          done: {
-            icon: "path to a png/svg file" // Changes the icon image of the retake button
+            icon: "path to a png/svg file" // Changes the icon image of the done button
             label: "Return Home", // Change the text label of the done button to the provided string; string is "Done" by default
             isHidden: true, // Hides the done button; false by default
             className: "custom class name" // to implement a custom css to the done button, you can assign a custom css class to the button here


### PR DESCRIPTION
## Summary
- Rewrite `gettingstarted/add_dependency.md` to use MRZ Scanner (`dynamsoft-mrz-scanner`) dependencies and correct engine path guidance.
- Fix API accuracy issues in `api/mrz-scanner.md` including `launch()` typing, `MRZData.age` type, toolbar config (`rescan`), `cancel` typing, and ResultStatus link.
- Add missing API docs for `MRZScanner.initialize()`, `MRZScannerView`, `MRZResultView`, and `ToolbarButton`.
- Add missing enum docs (`EnumMRZScanMode`, `EnumMRZScannerViews`) and missing enum values (`IssuingStateRaw`, `NationalityRaw`).
- Update `api/index.md` links/anchors for classes and enums.
- Update `guides/mrz-scanner-customization.md` examples to use `rescan` naming consistently.

## Verification
- Manual validation via targeted grep checks for corrected symbols, links, and removed incorrect package references.

## Related Issues
Closes #45
Closes #46
Closes #47
Closes #48
Closes #49
Closes #50
Closes #51
Closes #52
Closes #53
Closes #54
Closes #55